### PR TITLE
Fix class name utility bug

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -2,5 +2,5 @@ import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs) {
-	return twMerge(clsx(inputs));
+        return twMerge(clsx(...inputs));
 }


### PR DESCRIPTION
## Summary
- fix class name merge helper

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eca8280e48327acba8406f98f3dfe