### PR TITLE
Refactor tarifs section and unify image ratios

### DIFF
--- a/src/components/home/ContactSection.jsx
+++ b/src/components/home/ContactSection.jsx
@@ -54,7 +54,7 @@ const ContactSection = () => {
               title="Carte Paintball Méditerranée"
               aria-label="Emplacement sur Google Maps"
               src="https://www.google.com/maps?q=140+Passage+Charles+Tillon,+34070+Montpellier&output=embed"
-              className="rounded-xl w-full h-96 shadow-lg border-0"
+              className="rounded-xl w-full aspect-video h-auto shadow-lg border-0"
               loading="lazy"
             ></iframe>
           </motion.div>

--- a/src/components/home/HeroSection.jsx
+++ b/src/components/home/HeroSection.jsx
@@ -40,9 +40,9 @@ const HeroSection = () => {
             className="relative"
           >
             <div className="float-animation">
-              <img 
+              <img
                 alt="Joueur de paintball en armure de lapin futuriste"
-                className="rounded-2xl shadow-2xl w-full h-96 object-cover"
+                className="rounded-2xl shadow-2xl w-full aspect-video object-cover"
                 src={heroImageUrl} />
             </div>
             <div className="absolute -bottom-6 -left-6 glass-effect rounded-xl p-4">

--- a/src/components/home/TarifsSection.jsx
+++ b/src/components/home/TarifsSection.jsx
@@ -1,55 +1,66 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 
 const tarifs = [
-  { name: 'Découverte', billes: 120, duree: '40–60 min', prix: '20 €' },
-  { name: 'Méditerranée', billes: 200, duree: '60–90 min', prix: '25 €' },
-  { name: 'Player', billes: 300, duree: '90–120 min', prix: '30 €' },
-  { name: 'Punisher', billes: 400, duree: '90–120 min', prix: '35 €' },
-  { name: 'Expendable', billes: 600, duree: 'jusqu\u2019\u00e0 3h', prix: '45 €' },
-  { name: 'Enfant Gotcha', billes: 'billes lavables', duree: '6–10 ans', prix: '20 €' },
+  { name: 'Découverte', billes: '120 billes', duree: '40–60 min', prix: 20 },
+  { name: 'Méditerranée', billes: '200 billes', duree: '60–90 min', prix: 25 },
+  { name: 'Player', billes: '300 billes', duree: '90–120 min', prix: 30 },
+  { name: 'Punisher', billes: '400 billes', duree: '90–120 min', prix: 35 },
+  { name: 'Expendable', billes: '600 billes', duree: 'jusqu\u2019\u00e0 3h', prix: 45 },
+  { name: 'Enfant Gotcha', billes: 'billes lavables', duree: '6–10 ans', prix: 20 },
 ];
 
-const TarifsSection = () => {
-  return (
-    <section id="tarifs" className="py-20" data-aos="fade-up">
-      <div className="container mx-auto px-4">
-        <h2 className="text-4xl lg:text-5xl font-bold text-gradient mb-8 text-center">Nos tarifs</h2>
-        <div className="overflow-x-auto">
-          <table className="min-w-full text-left text-gray-300">
-            <thead className="bg-white/10 text-white">
-              <tr>
-                <th className="px-4 py-3">Formule</th>
-                <th className="px-4 py-3">Billes</th>
-                <th className="px-4 py-3">Durée</th>
-                <th className="px-4 py-3">Prix</th>
-                <th className="px-4 py-3"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {tarifs.map((t) => (
-                <tr key={t.name} className="border-b border-white/10">
-                  <td className="px-4 py-4 font-semibold text-white">{t.name}</td>
-                  <td className="px-4 py-4">{t.billes}</td>
-                  <td className="px-4 py-4">{t.duree}</td>
-                  <td className="px-4 py-4">{t.prix}</td>
-                  <td className="px-4 py-4">
-                    <Button
-                      aria-label={`Réserver la formule ${t.name}`}
-                      className="bg-orange-500 hover:bg-orange-600 text-white"
-                      onClick={() => document.getElementById('reservation')?.scrollIntoView({ behavior: 'smooth' })}
-                    >
-                      Réserver maintenant
-                    </Button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+const TarifsSection = () => (
+  <section id="tarifs" className="py-20">
+    <div className="container mx-auto px-4">
+      <motion.div
+        initial={{ y: 50, opacity: 0 }}
+        whileInView={{ y: 0, opacity: 1 }}
+        viewport={{ once: true }}
+        className="text-center mb-16"
+      >
+        <h2 className="text-4xl lg:text-5xl font-bold text-gradient mb-6">
+          Nos formules
+        </h2>
+        <p className="text-xl text-gray-300">
+          Choisissez la formule qui vous convient
+        </p>
+      </motion.div>
+
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+        {tarifs.map((t, index) => (
+          <motion.div
+            key={t.name}
+            initial={{ y: 50, opacity: 0 }}
+            whileInView={{ y: 0, opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ delay: index * 0.1 }}
+            className="glass-effect rounded-xl p-6 flex flex-col items-center text-center hover:scale-105 transition-transform"
+          >
+            <h3 className="text-2xl font-bold text-white mb-1">{t.name}</h3>
+            <p className="text-gray-300 mb-4">
+              {t.billes} – {t.duree}
+            </p>
+            <div className="text-4xl font-bold text-gradient mb-6">
+              {t.prix}€
+            </div>
+            <Button
+              aria-label={`Réserver la formule ${t.name}`}
+              className="bg-gradient-to-r from-orange-500 to-yellow-500 hover:from-orange-600 hover:to-yellow-600"
+              onClick={() =>
+                document
+                  .getElementById('reservation')
+                  ?.scrollIntoView({ behavior: 'smooth' })
+              }
+            >
+              Réserver maintenant
+            </Button>
+          </motion.div>
+        ))}
       </div>
-    </section>
-  );
-};
+    </div>
+  </section>
+);
 
 export default TarifsSection;

--- a/src/components/home/TerrainSection.jsx
+++ b/src/components/home/TerrainSection.jsx
@@ -57,17 +57,17 @@ const TerrainSection = () => {
             viewport={{ once: true }}
             className="grid grid-cols-2 gap-4"
           >
-            <img 
+            <img
               alt="Espace extérieur arboré du site de paintball"
-              className="rounded-xl h-56 w-full object-cover shadow-lg"
+              className="rounded-xl w-full aspect-video object-cover shadow-lg"
               src={terrainImage1Url} />
-            <img 
+            <img
               alt="Animateur briefant un groupe de joueurs de paintball"
-              className="rounded-xl h-56 w-full object-cover shadow-lg"
+              className="rounded-xl w-full aspect-video object-cover shadow-lg"
               src={terrainImage2Url} />
-            <img 
+            <img
               alt="Passage couvert de bambous menant aux terrains de paintball"
-              className="rounded-xl h-56 w-full object-cover col-span-2 shadow-lg"
+              className="rounded-xl w-full aspect-video object-cover col-span-2 shadow-lg"
               src={terrainImage3Url} />
           </motion.div>
         </div>


### PR DESCRIPTION
## Summary
- replace pricing table by animated cards in `TarifsSection`
- update hero and terrain images to use aspect ratio classes
- use responsive ratio for map iframe

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed539479c8327b91efa930f8ef650