### PR TITLE
Improve mobile layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,7 +35,7 @@ function App() {
                   <p className="text-xs text-gray-300 hidden sm:block">Montpellier</p>
                 </div>
               </Link>
-              <nav className="flex items-center space-x-1 md:space-x-4">
+              <nav className="flex flex-wrap items-center gap-2 md:space-x-4 text-sm">
                 <NavLink to="/" className={navLinkClasses}>Accueil</NavLink>
                 <NavLink to="/#terrain" className={navLinkClasses} onClick={() => setTimeout(() => document.getElementById('terrain')?.scrollIntoView({ behavior: 'smooth' }),0)}>Le Terrain</NavLink>
                 <NavLink to="/#forfaits" className={navLinkClasses} onClick={() => setTimeout(() => document.getElementById('forfaits')?.scrollIntoView({ behavior: 'smooth' }),0)}>Forfaits</NavLink>

--- a/src/components/home/ContactSection.jsx
+++ b/src/components/home/ContactSection.jsx
@@ -6,7 +6,7 @@ const contactImageUrl = "https://storage.googleapis.com/hostinger-horizons-asset
 
 const ContactSection = () => {
   return (
-    <section id="contact" className="py-20">
+  <section id="contact" className="py-16 sm:py-20">
       <div className="container mx-auto px-4">
         <motion.div
           initial={{ y: 50, opacity: 0 }}
@@ -15,30 +15,30 @@ const ContactSection = () => {
           className="text-center mb-16"
         >
           <h2 className="text-2xl md:text-4xl lg:text-5xl font-bold text-gradient mb-6">Contactez-nous</h2>
-          <p className="text-xl text-gray-300">Une question ? Nous sommes là pour vous aider !</p>
+          <p className="text-sm sm:text-xl text-gray-300">Une question ? Nous sommes là pour vous aider !</p>
         </motion.div>
 
-        <div className="grid lg:grid-cols-2 gap-12">
+        <div className="grid lg:grid-cols-2 gap-8 lg:gap-12">
           <motion.div
             initial={{ x: -100, opacity: 0 }}
             whileInView={{ x: 0, opacity: 1 }}
             viewport={{ once: true }}
             className="space-y-6"
           >
-            <div className="glass-effect rounded-xl p-6">
+            <div className="glass-effect rounded-xl p-4 sm:p-6">
               <Phone className="w-8 h-8 text-orange-400 mb-4" />
               <h3 className="text-xl font-semibold text-white mb-2">Téléphone</h3>
               <p className="text-gray-300">06 23 73 50 02</p>
               <p className="text-sm text-gray-400">Ouvert tous les jours sur réservation</p>
               <p className="text-sm text-gray-400">Fermé mardi et jeudi matin</p>
             </div>
-            <div className="glass-effect rounded-xl p-6">
+            <div className="glass-effect rounded-xl p-4 sm:p-6">
               <Mail className="w-8 h-8 text-orange-400 mb-4" />
               <h3 className="text-xl font-semibold text-white mb-2">Email</h3>
               <p className="text-gray-300">contact@paintball-mediterranee.fr</p>
               <p className="text-sm text-gray-400">Réponse sous 24h</p>
             </div>
-            <div className="glass-effect rounded-xl p-6">
+            <div className="glass-effect rounded-xl p-4 sm:p-6">
               <MapPin className="w-8 h-8 text-orange-400 mb-4" />
               <h3 className="text-xl font-semibold text-white mb-2">Adresse</h3>
               <p className="text-gray-300">140 Passage Charles Tillon,<br />34070 Montpellier</p>
@@ -54,7 +54,7 @@ const ContactSection = () => {
               title="Carte Paintball Méditerranée"
               aria-label="Emplacement sur Google Maps"
               src="https://www.google.com/maps?q=140+Passage+Charles+Tillon,+34070+Montpellier&output=embed"
-              className="rounded-xl w-full aspect-video h-auto shadow-lg border-0"
+              className="rounded-xl w-full aspect-video max-h-60 sm:max-h-none h-auto shadow-lg border-0"
               loading="lazy"
             ></iframe>
           </motion.div>

--- a/src/components/home/FeaturesSection.jsx
+++ b/src/components/home/FeaturesSection.jsx
@@ -11,9 +11,9 @@ const features = [
 
 const FeaturesSection = () => {
   return (
-    <section className="py-16">
+  <section className="py-12 sm:py-16">
       <div className="container mx-auto px-4">
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-8">
           {features.map((feature, index) => (
             <motion.div
               key={index}
@@ -21,11 +21,11 @@ const FeaturesSection = () => {
               whileInView={{ y: 0, opacity: 1 }}
               viewport={{ once: true }}
               transition={{ delay: index * 0.1 }}
-              className="glass-effect rounded-xl p-6 text-center hover:scale-105 transition-transform"
+              className="glass-effect rounded-xl p-4 sm:p-6 text-center hover:scale-105 transition-transform"
             >
-              <feature.icon className="w-12 h-12 text-orange-400 mx-auto mb-4" />
-              <h3 className="text-xl font-semibold text-white mb-2">{feature.title}</h3>
-              <p className="text-gray-300">{feature.desc}</p>
+                <feature.icon className="w-12 h-12 text-orange-400 mx-auto mb-4" />
+                <h3 className="text-lg sm:text-xl font-semibold text-white mb-2">{feature.title}</h3>
+                <p className="text-sm text-gray-300">{feature.desc}</p>
             </motion.div>
           ))}
         </div>

--- a/src/components/home/HeroSection.jsx
+++ b/src/components/home/HeroSection.jsx
@@ -7,21 +7,21 @@ const heroImageUrl = "https://storage.googleapis.com/hostinger-horizons-assets-p
 
 const HeroSection = () => {
   return (
-    <section id="accueil" className="relative py-20 overflow-hidden" data-aos="fade-up">
+    <section id="accueil" className="relative py-16 sm:py-20 overflow-hidden" data-aos="fade-up">
       <div className="container mx-auto px-4">
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
+        <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 items-center">
           <motion.div
             initial={{ x: -100, opacity: 0 }}
             animate={{ x: 0, opacity: 1 }}
             transition={{ delay: 0.2 }}
           >
-            <h1 className="text-5xl lg:text-7xl font-bold mb-6 text-white">
+            <h1 className="text-3xl sm:text-5xl lg:text-7xl font-bold mb-6 text-white">
               Paintball Méditerranée – le meilleur terrain de Montpellier
             </h1>
-            <p className="text-xl text-gray-300 mb-8 leading-relaxed">
+            <p className="text-sm sm:text-xl text-gray-300 mb-8 leading-relaxed">
               3 terrains de 4 hectares en pleine nature, en bord de rivière, avec zones ombragées, buvette, fléchettes et pétanque. Dès 7 ans, billes biodégradables. Réservation obligatoire.
             </p>
-            <div className="flex flex-wrap gap-4">
+            <div className="flex flex-col sm:flex-row gap-4">
               <Button
                 size="lg"
                 aria-label="Voir les formules"

--- a/src/components/home/PackagesSection.jsx
+++ b/src/components/home/PackagesSection.jsx
@@ -62,7 +62,7 @@ const packagesData = [
 
 const PackagesSection = ({ selectedPackage, onSelectPackage }) => {
   return (
-    <section id="forfaits" className="py-20">
+  <section id="forfaits" className="py-16 sm:py-20">
       <div className="container mx-auto px-4">
         <motion.div
           initial={{ y: 50, opacity: 0 }}
@@ -71,10 +71,10 @@ const PackagesSection = ({ selectedPackage, onSelectPackage }) => {
           className="text-center mb-16"
         >
           <h2 className="text-2xl md:text-4xl lg:text-5xl font-bold text-gradient mb-6">Nos forfaits</h2>
-          <p className="text-xl text-gray-300">Choisissez l'expérience qui vous correspond, pour adultes et enfants.</p>
+          <p className="text-sm sm:text-xl text-gray-300">Choisissez l'expérience qui vous correspond, pour adultes et enfants.</p>
         </motion.div>
 
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-8">
           {packagesData.map((pkg, index) => (
             <motion.div
               key={pkg.id}
@@ -82,7 +82,7 @@ const PackagesSection = ({ selectedPackage, onSelectPackage }) => {
               whileInView={{ y: 0, opacity: 1 }}
               viewport={{ once: true }}
               transition={{ delay: index * 0.1 }}
-              className={`glass-effect rounded-xl p-8 relative overflow-hidden hover:scale-105 transition-transform cursor-pointer ${
+              className={`glass-effect rounded-xl p-4 sm:p-8 relative overflow-hidden hover:scale-105 transition-transform cursor-pointer ${
                 selectedPackage === pkg.id ? 'ring-2 ring-orange-400' : ''
               }`}
               onClick={() => onSelectPackage(pkg.id)}
@@ -98,7 +98,7 @@ const PackagesSection = ({ selectedPackage, onSelectPackage }) => {
                 </div>
               )}
               <div className="text-center mb-6">
-                <h3 className="text-2xl font-bold text-white mb-2">{pkg.name}</h3>
+                <h3 className="text-xl sm:text-2xl font-bold text-white mb-2">{pkg.name}</h3>
                 <p className="text-gray-300 mb-4 h-12">{pkg.description}</p>
                 <div className="text-4xl font-bold text-gradient mb-2">{pkg.price}€</div>
                 <div className="flex flex-col sm:flex-row justify-center space-y-1 sm:space-y-0 sm:space-x-4 text-sm text-gray-300">
@@ -106,7 +106,7 @@ const PackagesSection = ({ selectedPackage, onSelectPackage }) => {
                   <span className="flex items-center justify-center"><Users className="w-4 h-4 mr-1" />{pkg.players}</span>
                 </div>
               </div>
-              <ul className="space-y-3 min-h-[100px]">
+              <ul className="space-y-3 min-h-[100px] text-sm">
                 {pkg.features.map((feature, i) => (
                   <li key={i} className="flex items-center text-gray-300">
                     <div className="w-2 h-2 bg-orange-400 rounded-full mr-3 shrink-0"></div>

--- a/src/components/home/ReservationSection.jsx
+++ b/src/components/home/ReservationSection.jsx
@@ -53,7 +53,7 @@ const Calendar = ({ currentMonth, selectedDate, onDateSelect, onMonthChange }) =
       initial={{ x: -100, opacity: 0 }}
       whileInView={{ x: 0, opacity: 1 }}
       viewport={{ once: true }}
-      className="glass-effect rounded-xl p-6"
+      className="glass-effect rounded-xl p-4 sm:p-6 overflow-hidden"
     >
       <div className="flex items-center justify-between mb-6">
         <h3 className="text-xl font-semibold text-white">Choisir une date</h3>
@@ -149,7 +149,7 @@ const BookingSummary = ({
       viewport={{ once: true }}
       className="space-y-6"
     >
-      <div className="glass-effect rounded-xl p-6">
+      <div className="glass-effect rounded-xl p-4 sm:p-6">
         <h3 className="text-xl font-semibold text-white mb-4">Horaires disponibles</h3>
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
           {timeSlots.map(time => (
@@ -171,7 +171,7 @@ const BookingSummary = ({
         </div>
       </div>
 
-      <div className="glass-effect rounded-xl p-6">
+      <div className="glass-effect rounded-xl p-4 sm:p-6">
         <h3 className="text-xl font-semibold text-white mb-4">Récapitulatif</h3>
         <div className="space-y-3 text-sm">
           <div className="flex justify-between">
@@ -209,7 +209,7 @@ const BookingSummary = ({
             </>
           )}
         </div>
-        <div className="grid sm:grid-cols-2 gap-4 mt-6">
+        <div className="grid sm:grid-cols-2 gap-4 mt-6 text-sm">
           <div>
             <Label htmlFor="firstName" className="text-white">Prénom</Label>
             <Input
@@ -369,11 +369,11 @@ const ReservationSection = ({ selectedPackage, onSelectPackage }) => {
           className="text-center mb-16"
         >
           <h2 className="text-2xl md:text-4xl lg:text-5xl font-bold text-gradient mb-6">Réservez votre session</h2>
-          <p className="text-xl text-gray-300">Sélectionnez votre date et horaire préférés</p>
+          <p className="text-sm sm:text-xl text-gray-300">Sélectionnez votre date et horaire préférés</p>
         </motion.div>
 
         <div className="max-w-4xl mx-auto">
-          <div className="grid lg:grid-cols-2 gap-8">
+          <div className="grid lg:grid-cols-2 gap-4 lg:gap-8">
             <div>
               <Calendar
                 currentMonth={currentMonth}

--- a/src/components/home/TarifsSection.jsx
+++ b/src/components/home/TarifsSection.jsx
@@ -12,7 +12,7 @@ const tarifs = [
 ];
 
 const TarifsSection = () => (
-  <section id="tarifs" className="py-20">
+  <section id="tarifs" className="py-16 sm:py-20">
     <div className="container mx-auto px-4">
       <motion.div
         initial={{ y: 50, opacity: 0 }}
@@ -23,12 +23,12 @@ const TarifsSection = () => (
         <h2 className="text-4xl lg:text-5xl font-bold text-gradient mb-6">
           Nos formules
         </h2>
-        <p className="text-xl text-gray-300">
+        <p className="text-sm sm:text-xl text-gray-300">
           Choisissez la formule qui vous convient
         </p>
       </motion.div>
 
-      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-8">
         {tarifs.map((t, index) => (
           <motion.div
             key={t.name}
@@ -36,9 +36,9 @@ const TarifsSection = () => (
             whileInView={{ y: 0, opacity: 1 }}
             viewport={{ once: true }}
             transition={{ delay: index * 0.1 }}
-            className="glass-effect rounded-xl p-6 flex flex-col items-center text-center hover:scale-105 transition-transform"
+            className="glass-effect rounded-xl p-4 sm:p-6 flex flex-col items-center text-center hover:scale-105 transition-transform"
           >
-            <h3 className="text-2xl font-bold text-white mb-1">{t.name}</h3>
+            <h3 className="text-xl sm:text-2xl font-bold text-white mb-1">{t.name}</h3>
             <p className="text-gray-300 mb-4">
               {t.billes} – {t.duree}
             </p>
@@ -47,7 +47,7 @@ const TarifsSection = () => (
             </div>
             <Button
               aria-label={`Réserver la formule ${t.name}`}
-              className="bg-gradient-to-r from-orange-500 to-yellow-500 hover:from-orange-600 hover:to-yellow-600"
+              className="w-full bg-gradient-to-r from-orange-500 to-yellow-500 hover:from-orange-600 hover:to-yellow-600"
               onClick={() =>
                 document
                   .getElementById('reservation')

--- a/src/components/home/TerrainSection.jsx
+++ b/src/components/home/TerrainSection.jsx
@@ -9,7 +9,7 @@ const terrainImage3Url = "https://storage.googleapis.com/hostinger-horizons-asse
 
 const TerrainSection = () => {
   return (
-    <section id="terrain" className="py-20">
+  <section id="terrain" className="py-12 sm:py-20">
       <div className="container mx-auto px-4">
         <motion.div
           initial={{ y: 50, opacity: 0 }}
@@ -18,33 +18,33 @@ const TerrainSection = () => {
           className="text-center mb-16"
         >
           <h2 className="text-2xl md:text-4xl lg:text-5xl font-bold text-gradient mb-6">Découvrez nos terrains et espaces</h2>
-          <p className="text-xl text-gray-300 max-w-3xl mx-auto">
+          <p className="text-sm sm:text-xl text-gray-300 max-w-3xl mx-auto">
             Plusieurs terrains de jeu, des niveaux de difficulté variés, et un espace détente unique.
           </p>
         </motion.div>
 
-        <div className="grid lg:grid-cols-2 gap-12 items-start">
+        <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 items-start">
           <motion.div
             initial={{ x: -100, opacity: 0 }}
             whileInView={{ x: 0, opacity: 1 }}
             viewport={{ once: true }}
             className="space-y-6"
           >
-            <div className="glass-effect rounded-xl p-6">
+            <div className="glass-effect rounded-xl p-4 sm:p-6">
               <MapPin className="w-8 h-8 text-orange-400 mb-4" />
               <h3 className="text-2xl font-semibold text-white mb-3">Deux terrains, multiples ambiances</h3>
               <p className="text-gray-300">
                 Explorez nos deux terrains distincts offrant des défis variés : un village western abandonné et une zone de bunkers tactiques. Différents niveaux de jeu pour s'adapter à tous les joueurs.
               </p>
             </div>
-            <div className="glass-effect rounded-xl p-6">
+            <div className="glass-effect rounded-xl p-4 sm:p-6">
               <Sun className="w-8 h-8 text-yellow-400 mb-2 inline-block" />
               <Moon className="w-8 h-8 text-blue-300 mb-2 inline-block ml-2" />
               <h3 className="text-2xl font-semibold text-white mb-3">Espace détente & soirée</h3>
               <p className="text-gray-300">
                 Profitez de notre espace détente avec tables, lumière d'ambiance pour vos soirées, plancha à disposition et un accès direct à la rivière pour vous rafraîchir. Parfait pour prolonger l'expérience après le jeu.
               </p>
-              <div className="flex flex-wrap gap-4 mt-4">
+              <div className="flex flex-wrap gap-4 mt-4 text-sm">
                   <span className="flex items-center text-gray-200 glass-effect px-3 py-1 rounded-full text-sm"><Grill className="w-4 h-4 mr-2 text-orange-400" /> Plancha</span>
                   <span className="flex items-center text-gray-200 glass-effect px-3 py-1 rounded-full text-sm"><Waves className="w-4 h-4 mr-2 text-blue-400" /> Rivière</span>
                   <span className="flex items-center text-gray-200 glass-effect px-3 py-1 rounded-full text-sm"><Moon className="w-4 h-4 mr-2 text-yellow-300" /> Soirées</span>
@@ -55,19 +55,19 @@ const TerrainSection = () => {
             initial={{ x: 100, opacity: 0 }}
             whileInView={{ x: 0, opacity: 1 }}
             viewport={{ once: true }}
-            className="grid grid-cols-2 gap-4"
+            className="grid grid-cols-2 gap-4 overflow-hidden"
           >
             <img
               alt="Espace extérieur arboré du site de paintball"
-              className="rounded-xl w-full aspect-video object-cover shadow-lg"
+              className="rounded-xl w-full aspect-video max-h-60 sm:max-h-full object-cover shadow-lg"
               src={terrainImage1Url} />
             <img
               alt="Animateur briefant un groupe de joueurs de paintball"
-              className="rounded-xl w-full aspect-video object-cover shadow-lg"
+              className="rounded-xl w-full aspect-video max-h-60 sm:max-h-full object-cover shadow-lg"
               src={terrainImage2Url} />
             <img
               alt="Passage couvert de bambous menant aux terrains de paintball"
-              className="rounded-xl w-full aspect-video object-cover col-span-2 shadow-lg"
+              className="rounded-xl w-full aspect-video max-h-60 sm:max-h-full object-cover col-span-2 shadow-lg"
               src={terrainImage3Url} />
           </motion.div>
         </div>

--- a/src/pages/ProQuotePage.jsx
+++ b/src/pages/ProQuotePage.jsx
@@ -51,7 +51,7 @@ const ProQuotePage = () => {
   return (
     <motion.section 
       id="espace-pro" 
-      className="py-20"
+      className="py-16 sm:py-20"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
@@ -65,14 +65,14 @@ const ProQuotePage = () => {
         >
           <Briefcase className="w-16 h-16 text-orange-400 mx-auto mb-6" />
           <h1 className="text-4xl lg:text-5xl font-bold text-gradient mb-6">Espace Professionnels & Groupes</h1>
-          <p className="text-xl text-gray-300 max-w-3xl mx-auto">
+          <p className="text-sm sm:text-xl text-gray-300 max-w-3xl mx-auto">
             Organisez vos événements d'entreprise, team building, ou sorties de groupe sur mesure. 
             Remplissez le formulaire ci-dessous pour obtenir un devis personnalisé.
           </p>
         </motion.div>
 
         <motion.div 
-          className="max-w-2xl mx-auto glass-effect rounded-xl p-8 shadow-2xl"
+          className="max-w-2xl mx-auto glass-effect rounded-xl p-4 sm:p-8 shadow-2xl"
           initial={{ scale: 0.9, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
           transition={{ delay: 0.2, duration: 0.5 }}
@@ -104,7 +104,7 @@ const ProQuotePage = () => {
                 required 
               />
             </div>
-            <div className="grid md:grid-cols-2 gap-6">
+            <div className="grid md:grid-cols-2 gap-4 sm:gap-6">
               <div>
                 <Label htmlFor="email" className="text-white">Email *</Label>
                 <Input 
@@ -131,7 +131,7 @@ const ProQuotePage = () => {
                 />
               </div>
             </div>
-            <div className="grid md:grid-cols-2 gap-6">
+            <div className="grid md:grid-cols-2 gap-4 sm:gap-6">
               <div>
                 <Label htmlFor="numParticipants" className="text-white">Nombre de participants (estimé) *</Label>
                 <Input 

--- a/src/pages/ReservationPage.jsx
+++ b/src/pages/ReservationPage.jsx
@@ -51,11 +51,11 @@ const ReservationPage = () => {
   };
 
   return (
-    <section className="py-12">
+    <section className="py-12 sm:py-16">
       <div className="container mx-auto px-4">
         <h1 className="text-xl md:text-2xl font-bold text-center mb-8">Réserver une session</h1>
-        <form onSubmit={handleSubmit} className="max-w-2xl mx-auto rounded-xl p-6 shadow-md bg-white">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <form onSubmit={handleSubmit} className="max-w-2xl mx-auto rounded-xl p-4 sm:p-6 shadow-md bg-white">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
             <div>
               <Label htmlFor="firstName">Prénom</Label>
               <Input


### PR DESCRIPTION
## Summary
- refine header navigation spacing on small screens
- scale down hero text and spacing
- adjust features and terrain sections for small devices
- tweak package and tarifs cards for mobile
- update reservation, contact and pro quote pages
- reduce spacing on reservation page form

## Testing
- `npm run build` *(fails: Permission denied and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684ee98c152083278edfad46bb106ae0